### PR TITLE
Fix crash in DWriteCoreGallery sample

### DIFF
--- a/DWriteCore/DWriteCoreGallery/DWriteCoreGallery/FontFamilyListWindow.cpp
+++ b/DWriteCore/DWriteCoreGallery/DWriteCoreGallery/FontFamilyListWindow.cpp
@@ -92,7 +92,7 @@ void FontFamilyListWindow::DrawItem(TextRenderer* textRenderer, int itemIndex, b
 
     // Set the maximum width, for trimming.
     float widthInDips = GetPixelWidth() / textRenderer->GetDpiScale();
-    THROW_IF_FAILED(textLayout->SetMaxWidth(widthInDips - g_leftMargin));
+    THROW_IF_FAILED(textLayout->SetMaxWidth(std::max(0.0f, widthInDips - g_leftMargin)));
 
     // Draw the text.
     THROW_IF_FAILED(textLayout->Draw(nullptr, textRenderer, g_leftMargin, g_topMargin));


### PR DESCRIPTION
This fixes a crash in the DWriteCoreGallery sample when the window is slowly resized such that the font list width is less than its left margin. This results in the app passing a negative value to IDWriteTextLayout::SetMaxWidth, which returns E_INVALIDARG.

Closes #22 