### PR TITLE
Change DWriteCreateFactory to DWriteCoreCreateFactory

### DIFF
--- a/DWriteCore/DWriteCoreGallery/DWriteCoreGallery/Main.cpp
+++ b/DWriteCore/DWriteCoreGallery/DWriteCoreGallery/Main.cpp
@@ -29,7 +29,7 @@ int APIENTRY wWinMain(
 
 #ifndef USE_INBOX_DWRITE
     // Initialize the global factory object.
-    THROW_IF_FAILED(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory7), reinterpret_cast<IUnknown**>(&g_factory)));
+    THROW_IF_FAILED(DWriteCoreCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory7), reinterpret_cast<IUnknown**>(&g_factory)));
 #else
     auto moduleHandle = LoadLibraryW(L"DWrite.dll");
     THROW_LAST_ERROR_IF_NULL(moduleHandle);


### PR DESCRIPTION
Change DWriteCoreGallery sample to call DWriteCoreCreateFactory instead of DWriteCreateFactory.

Both functions are identical, but DWriteCoreCreateFactory avoids ambiguity with the exported function from the in-box DWrite.dll. The DWriteCreateFactory export will eventually be removed from DWriteCore.dll.