### PR TITLE
For the C# WinUI MRT Core sample app, fix the nuget restore error.

### DIFF
--- a/MrtCore/winui_desktop_packaged_app/winui_desktop_packaged_app (Package)/winui_desktop_packaged_app (Package).wapproj
+++ b/MrtCore/winui_desktop_packaged_app/winui_desktop_packaged_app (Package)/winui_desktop_packaged_app (Package).wapproj
@@ -38,6 +38,7 @@
     <ProjectGuid>28b258ca-5ecc-41ee-a5b0-c2f24f3a4984</ProjectGuid>
     <TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
+    <AssetTargetFallback>net5.0-windows$(TargetPlatformVersion);$(AssetTargetFallback)</AssetTargetFallback>
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
   </PropertyGroup>
@@ -54,7 +55,6 @@
     <Content Include="Images\Square44x44Logo.targetsize-24_altform-unplated.png" />
     <Content Include="Images\StoreLogo.png" />
     <Content Include="Images\Wide310x150Logo.scale-200.png" />
-    <None Include="winui_desktop_packaged_app %28Package%29_TemporaryKey.pfx" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\winui_desktop_packaged_app\winui_desktop_packaged_app.csproj">

--- a/MrtCore/winui_desktop_packaged_app/winui_desktop_packaged_app/App.xaml.cs
+++ b/MrtCore/winui_desktop_packaged_app/winui_desktop_packaged_app/App.xaml.cs
@@ -2,25 +2,9 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
 using System.Runtime.InteropServices;
-using Windows.ApplicationModel;
-using Windows.ApplicationModel.Activation;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
 using Microsoft.ApplicationModel.Resources;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Data;
-using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Navigation;
-using Microsoft.UI.Xaml.Shapes;
 using WinRT;
 
 
@@ -66,9 +50,10 @@ namespace winui_desktop_packaged_app
 
             m_window = new MainWindow(m_resourceLoader, m_resourceManager);
 
-            //Get the Window's HWND
+            // Get the Window's HWND
             var windowNative = m_window.As<IWindowNative>();
-            m_window.Title = "MRT Core C# sample";
+            // Needs to be set in code due to bug https://github.com/microsoft/microsoft-ui-xaml/issues/3689
+            m_window.Title = "MRT Core C# sample";            
             m_window.Activate();
 
             // The Window object doesn't have Width and Height properties in WInUI 3 Desktop yet.

--- a/MrtCore/winui_desktop_packaged_app/winui_desktop_packaged_app/MainWindow.xaml.cs
+++ b/MrtCore/winui_desktop_packaged_app/winui_desktop_packaged_app/MainWindow.xaml.cs
@@ -1,20 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Data;
-using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Navigation;
 using Microsoft.ApplicationModel.Resources;
 using SampleLibrary;
 
@@ -23,9 +10,6 @@ using SampleLibrary;
 
 namespace winui_desktop_packaged_app
 {
-    /// <summary>
-    /// An empty window that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class MainWindow : Window
     {
         public MainWindow(ResourceLoader resourceLoader, ResourceManager resourceManager)

--- a/MrtCore/winui_desktop_packaged_app_cpp/winui_desktop_packaged_app_cpp (Package)/winui_desktop_packaged_app_cpp (Package).wapproj
+++ b/MrtCore/winui_desktop_packaged_app_cpp/winui_desktop_packaged_app_cpp (Package)/winui_desktop_packaged_app_cpp (Package).wapproj
@@ -57,7 +57,6 @@
     <Content Include="Images\Square44x44Logo.targetsize-24_altform-unplated.png" />
     <Content Include="Images\StoreLogo.png" />
     <Content Include="Images\Wide310x150Logo.scale-200.png" />
-    <None Include="winui_desktop_packaged_app_cpp %28Package%29_TemporaryKey.pfx" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\winui_desktop_packaged_app_cpp\winui_desktop_packaged_app_cpp.vcxproj">


### PR DESCRIPTION
For the C# WinUI MRT Core sample app, this fixes the nuget restore error and makes some other small improvements.

I checked to see if nuget restore works for the CPP sample and the C# class lib. It does. (I ran: `msbuild .\winui_desktop_packaged_app_cpp.sln /bl -t:restore` and `msbuild .\winui_class_lib.sln /bl -t:restore`)

**How verified**
Built and ran the app.
Ran: `msbuild .\winui_desktop_packaged_app.sln /bl -t:restore`